### PR TITLE
shinano: Check host for Dalvik preoptimization

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -111,7 +111,9 @@ BOARD_NFC_HAL_SUFFIX := $(TARGET_BOARD_PLATFORM)
 EXTENDED_FONT_FOOTPRINT := true
 
 # Enable dex-preoptimization to speed up first boot sequence
-WITH_DEXPREOPT := true
+ifeq ($(HOST_OS),linux)
+    WITH_DEXPREOPT ?= true
+endif
 
 BUILD_KERNEL := true
 -include vendor/sony/kernel/KernelConfig.mk


### PR DESCRIPTION
Turn ON Dalvik preoptimization if the build is running on Linux hosts
(since host Dalvik isn't built for non-Linux hosts)

Signed-off-by: Humberto Borba humberos@gmail.com
