### PR TITLE
kanuti: remove flac decoder

### DIFF
--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -69,6 +69,14 @@ audio_hw_modules {
         devices AUDIO_DEVICE_OUT_ALL_A2DP
       }
     }
+    inputs {
+      a2dp {
+        sampling_rates 44100|48000
+        channel_masks AUDIO_CHANNEL_IN_MONO|AUDIO_CHANNEL_IN_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_IN_BLUETOOTH_A2DP
+      }
+    }
   }
   usb {
     outputs {
@@ -88,8 +96,8 @@ audio_hw_modules {
     inputs {
       usb_device {
         sampling_rates dynamic
-        channel_masks AUDIO_CHANNEL_IN_STEREO
-        formats AUDIO_FORMAT_PCM_16_BIT
+        channel_masks dynamic
+        formats dynamic
         devices AUDIO_DEVICE_IN_USB_DEVICE
       }
     }
@@ -113,4 +121,3 @@ audio_hw_modules {
     }
   }
 }
-

--- a/rootdir/system/etc/media_codecs.xml
+++ b/rootdir/system/etc/media_codecs.xml
@@ -107,17 +107,6 @@ Only the three quirks included above are recognized at this point:
     <Include href="media_codecs_google_audio.xml" />
     <Include href="media_codecs_google_telephony.xml" />
     <Encoders>
-        <!-- Audio Hardware  -->
-        <MediaCodec name="OMX.qcom.audio.encoder.evrc" type="audio/evrc" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qcom.audio.encoder.qcelp13" type="audio/qcelp" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-        </MediaCodec>
-        <!-- Audio Software  -->
-        <!-- Video Hardware  -->
         <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
@@ -170,19 +159,6 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
     </Encoders>
     <Decoders>
-        <!-- Audio Hardware  -->
-        <MediaCodec name="OMX.qcom.audio.decoder.wma" type="audio/x-ms-wma" >
-            <Quirk name="requires-global-flush" />
-            <Quirk name="requires-wma-pro-component" />
-        </MediaCodec>
-        <!-- Audio Software  -->
-        <MediaCodec name="OMX.qcom.audio.decoder.Qcelp13" type="audio/qcelp" >
-            <Quirk name="requires-global-flush" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qcom.audio.decoder.evrc" type="audio/evrc" >
-            <Quirk name="requires-global-flush" />
-        </MediaCodec>
-        <!-- Video Hardware  -->
         <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />

--- a/rootdir/system/etc/media_codecs.xml
+++ b/rootdir/system/etc/media_codecs.xml
@@ -177,8 +177,6 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
         <!-- Audio Software  -->
         <MediaCodec name="OMX.google.aac.decoder" type="audio/mp4a-latm" />
-        <MediaCodec name="OMX.somc.alac.decoder" type="audio/alac" />
-        <MediaCodec name="OMX.somc.dsd.decoder" type="audio/dsd"/>
         <MediaCodec name="OMX.qcom.audio.decoder.Qcelp13" type="audio/qcelp" >
             <Quirk name="requires-global-flush" />
         </MediaCodec>

--- a/rootdir/system/etc/media_codecs.xml
+++ b/rootdir/system/etc/media_codecs.xml
@@ -185,7 +185,6 @@ Only the three quirks included above are recognized at this point:
         <MediaCodec name="OMX.qcom.audio.decoder.evrc" type="audio/evrc" >
             <Quirk name="requires-global-flush" />
         </MediaCodec>
-        <MediaCodec name="OMX.sony.flac.decoder" type="audio/flac"/>
         <!-- Video Hardware  -->
         <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" >
             <Quirk name="requires-allocate-on-input-ports" />

--- a/rootdir/system/etc/media_codecs.xml
+++ b/rootdir/system/etc/media_codecs.xml
@@ -176,7 +176,6 @@ Only the three quirks included above are recognized at this point:
             <Quirk name="requires-wma-pro-component" />
         </MediaCodec>
         <!-- Audio Software  -->
-        <MediaCodec name="OMX.google.aac.decoder" type="audio/mp4a-latm" />
         <MediaCodec name="OMX.qcom.audio.decoder.Qcelp13" type="audio/qcelp" >
             <Quirk name="requires-global-flush" />
         </MediaCodec>


### PR DESCRIPTION
it's related to sony proprietary blobs and not from AOSP

Signed-off-by: David Viteri davidteri91@gmail.com
