### PR TITLE
kanuti: update backup service for apps

### DIFF
--- a/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -18,4 +18,5 @@
 -->
 <resources>
     <bool name="def_screen_brightness_automatic_mode">true</bool>
+    <string name="def_backup_transport">com.google.android.backup/.BackupTransportService</string>
 </resources>


### PR DESCRIPTION
actually we are using that defined on: https://android.googlesource.com/platform/frameworks/base/+/android-5.1.1_r24/packages/SettingsProvider/res/values/defaults.xml#56

but the correct for lollipop is defined on device/sample: https://android.googlesource.com/device/sample/+/android-5.1.1_r24/overlays/backup/frameworks/base/packages/SettingsProvider/res/values/defaults.xml#20

Signed-off-by: David Viteri davidteri91@gmail.com
