### PR TITLE
kanuti: Update audio_effects

### DIFF
--- a/rootdir/system/etc/audio_effects.conf
+++ b/rootdir/system/etc/audio_effects.conf
@@ -1,22 +1,3 @@
-#
-# This file was modified by Dolby Laboratories, Inc. The portions of the
-# code that are surrounded by "DOLBY..." are copyrighted and
-# licensed separately, as follows:
-#
-#  (C) 2012-2014 Dolby Laboratories, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 # List of effect libraries to load. Each library element must contain a "path" element
 # giving the full path of the library .so file.
 #    libraries {
@@ -25,43 +6,33 @@
 #        }
 #    }
 libraries {
-# This is a proxy library that will be an abstraction for
-# the HW and SW effects
-
-  #proxy {
-    #path /system/lib/soundfx/libeffectproxy.so
-  #}
-
-# This is the SW implementation library of the effect
-  #libSW {
-    #path /system/lib/soundfx/libswwrapper.so
-  #}
-
-# This is the HW implementation library for the effect
-  #libHW {
-    #path /system/lib/soundfx/libhwwrapper.so
-  #}
-
   bundle {
     path /system/lib/soundfx/libbundlewrapper.so
   }
   reverb {
     path /system/lib/soundfx/libreverbwrapper.so
   }
-  visualizer {
+  visualizer_sw {
     path /system/lib/soundfx/libvisualizer.so
+  }
+  visualizer_hw {
+    path /system/lib/soundfx/libqcomvisualizer.so
   }
   downmix {
     path /system/lib/soundfx/libdownmix.so
   }
+  proxy {
+    path /system/lib/soundfx/libeffectproxy.so
+  }
+  offload_bundle {
+    path /system/lib/soundfx/libqcompostprocbundle.so
+  }
+  qcom_pre_processing {
+    path /system/lib/soundfx/libqcomvoiceprocessing.so
+  }
   loudness_enhancer {
     path /system/lib/soundfx/libldnhncr.so
   }
-#DOLBY_DAP
-  ds {
-    path /system/vendor/lib/soundfx/libswdap.so
-  }
-#DOLBY_END
 }
 
 # Default pre-processing library. Add to audio_effect.conf "libraries" section if
@@ -110,40 +81,120 @@ effects {
   #} End of effect proxy
 
   bassboost {
-    library bundle
-    uuid 8631f300-72e2-11df-b57e-0002a5d5c51b
+    library proxy
+    uuid 14804144-a5ee-4d24-aa88-0002a5d5c51b
+
+    libsw {
+      library bundle
+      uuid 8631f300-72e2-11df-b57e-0002a5d5c51b
+    }
+
+    libhw {
+      library offload_bundle
+      uuid 2c4a8c24-1581-487f-94f6-0002a5d5c51b
+    }
   }
   virtualizer {
-    library bundle
-    uuid 1d4033c0-8557-11df-9f2d-0002a5d5c51b
+    library proxy
+    uuid d3467faa-acc7-4d34-acaf-0002a5d5c51b
+
+    libsw {
+      library bundle
+      uuid 1d4033c0-8557-11df-9f2d-0002a5d5c51b
+    }
+
+    libhw {
+      library offload_bundle
+      uuid 509a4498-561a-4bea-b3b1-0002a5d5c51b
+    }
   }
   equalizer {
-    library bundle
-    uuid ce772f20-847d-11df-bb17-0002a5d5c51b
+    library proxy
+    uuid c8e70ecd-48ca-456e-8a4f-0002a5d5c51b
+
+    libsw {
+      library bundle
+      uuid ce772f20-847d-11df-bb17-0002a5d5c51b
+    }
+
+    libhw {
+      library offload_bundle
+      uuid a0dac280-401c-11e3-9379-0002a5d5c51b
+    }
   }
   volume {
     library bundle
     uuid 119341a0-8469-11df-81f9-0002a5d5c51b
   }
   reverb_env_aux {
-    library reverb
-    uuid 4a387fc0-8ab3-11df-8bad-0002a5d5c51b
+    library proxy
+    uuid 48404ac9-d202-4ccc-bf84-0002a5d5c51b
+
+    libsw {
+      library reverb
+      uuid 4a387fc0-8ab3-11df-8bad-0002a5d5c51b
+    }
+
+    libhw {
+      library offload_bundle
+      uuid 79a18026-18fd-4185-8233-0002a5d5c51b
+    }
   }
   reverb_env_ins {
-    library reverb
-    uuid c7a511a0-a3bb-11df-860e-0002a5d5c51b
+    library proxy
+    uuid b707403a-a1c1-4291-9573-0002a5d5c51b
+
+    libsw {
+      library reverb
+      uuid c7a511a0-a3bb-11df-860e-0002a5d5c51b
+    }
+
+    libhw {
+      library offload_bundle
+      uuid eb64ea04-973b-43d2-8f5e-0002a5d5c51b
+    }
   }
   reverb_pre_aux {
-    library reverb
-    uuid f29a1400-a3bb-11df-8ddc-0002a5d5c51b
+    library proxy
+    uuid 1b78f587-6d1c-422e-8b84-0002a5d5c51b
+
+    libsw {
+      library reverb
+      uuid f29a1400-a3bb-11df-8ddc-0002a5d5c51b
+    }
+
+    libhw {
+      library offload_bundle
+      uuid 6987be09-b142-4b41-9056-0002a5d5c51b
+    }
   }
   reverb_pre_ins {
-    library reverb
-    uuid 172cdf00-a3bc-11df-a72f-0002a5d5c51b
+    library proxy
+    uuid f3e178d2-ebcb-408e-8357-0002a5d5c51b
+
+    libsw {
+      library reverb
+      uuid 172cdf00-a3bc-11df-a72f-0002a5d5c51b
+    }
+
+    libhw {
+      library offload_bundle
+      uuid aa2bebf6-47cf-4613-9bca-0002a5d5c51b
+    }
   }
   visualizer {
-    library visualizer
-    uuid d069d9e0-8329-11df-9168-0002a5d5c51b
+    library proxy
+    uuid ec7178ec-e5e1-4432-a3f4-4657e6795210
+
+    libsw {
+      library visualizer_sw
+      uuid  d069d9e0-8329-11df-9168-0002a5d5c51b
+    }
+
+    libhw {
+      library visualizer_hw
+      uuid 7a8044a0-1a71-11e3-a184-0002a5d5c51b
+    }
   }
   downmix {
     library downmix
@@ -153,12 +204,6 @@ effects {
     library loudness_enhancer
     uuid fa415329-2034-4bea-b5dc-5b381c8d1e2c
   }
-#DOLBY_DAP
-  ds {
-    library ds
-    uuid 9d4921da-8225-4f29-aefa-39537a04bcaa
-  }
-#DOLBY_END
 }
 
 # Default pre-processing effects. Add to audio_effect.conf "effects" section if


### PR DESCRIPTION
Follow Nexus Configuration:
remove paths for (libqcbassboost.so - libqcvirt.so - libqcreverb.so)
remove paths for aec and ns
remove DOLBY_DAP which requires proprietary lib (doesn't provided by AOSP)
changes made for alleviate claims from AUDIO_EFFECTS_SESSION when play music due to missing libs on M libs release

Signed-off-by: David Viteri davidteri91@gmail.com
