### PR TITLE
kanuti: fix typo

### DIFF
--- a/rootdir/system/etc/media_profiles.xml
+++ b/rootdir/system/etc/media_profiles.xml
@@ -353,7 +353,7 @@
     <VideoEncoderCap name="m4v" enabled="true"
         minBitRate="64000" maxBitRate="20000000"
         minFrameWidth="176" maxFrameWidth="1920"
-        minFrameHeight="144" maxFrameHeight="1088"
+        minFrameHeight="144" maxFrameHeight="1080"
         minFrameRate="3" maxFrameRate="30"
         maxHFRFrameWidth="0" maxHFRFrameHeight="0"
         maxHFRMode="0"  />


### PR DESCRIPTION
fix typo for maxFrameHeight which is 1080 not 1088

Signed-off-by: David Viteri davidteri91@gmail.com
