### PR TITLE
kanuti: Remove persist.sys.usb.config override

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -236,7 +236,6 @@ $(call add-product-dex-preopt-module-config,services,--compiler-filter=speed)
 # Platform specific default properties
 #
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-    persist.sys.usb.config=mtp \
     persist.data.qmi.adb_logmask=0
 
 # Enable MultiWindow


### PR DESCRIPTION
The variable persist.sys.usb.config is no longer honored by the framework,
and it's presence causes unnecessary toggling of the USB driver, which
disconnects ADB and makes the device's connection unstable.

Delete it.

Signed-off-by: Humberto Borba humberos@gmail.com
