### PR TITLE
kanuti: update file_contexts

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -2,6 +2,7 @@
 /dev/socket/tad                        u:object_r:tad_socket:s0
 
 /dev/pn547                             u:object_r:nfc_device:s0
+/dev/pn54x                             u:object_r:nfc_device:s0
 
 # Block devices
 /dev/block/platform/soc.0/by-name/modemst1          u:object_r:modem_efs_partition_device:s0
@@ -11,11 +12,11 @@
 
 /data/etc/bluetooth_bdaddr             u:object_r:addrsetup_data_file:s0
 
-/system/vendor/bin/addrsetup                  u:object_r:addrsetup_exec:s0
+/system/bin/thermanager                       u:object_r:thermanager_exec:s0
+/system/bin/timekeep                          u:object_r:timekeep_exec:s0
+/system/bin/macaddrsetup                      u:object_r:addrsetup_exec:s0
 /system/vendor/bin/sct_service                u:object_r:sct_exec:s0
 /system/vendor/bin/tad_static                 u:object_r:tad_exec:s0
 /system/vendor/bin/ta_qmi_service             u:object_r:ta_qmi_exec:s0
-/system/vendor/bin/thermanager                u:object_r:thermanager_exec:s0
-/system/vendor/bin/timekeep                   u:object_r:timekeep_exec:s0
 
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0


### PR DESCRIPTION
add generic nfc driver pn54x
correct paths for macaddrsetup timekeep and thermanager those are compiled from source not provided by sony

Signed-off-by: David Viteri davidteri91@gmail.com
