### PR TITLE
sepolicy: update for blobs moved to /vendor/bin

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -19,4 +19,13 @@
 /system/vendor/bin/tad_static                 u:object_r:tad_exec:s0
 /system/vendor/bin/ta_qmi_service             u:object_r:ta_qmi_exec:s0
 
+# QCOM Blobs moved from /system/bin to /system/vendor/bin
+/system/vendor/bin/irsc_util                  u:object_r:irsc_util_exec:s0
+/system/vendor/bin/mm-qcamera-daemon          u:object_r:mm-qcamerad_exec:s0
+/system/vendor/bin/netmgrd                    u:object_r:netmgrd_exec:s0
+/system/vendor/bin/qmuxd                      u:object_r:qmuxd_exec:s0
+/system/vendor/bin/rmt_storage                u:object_r:rmt_storage_exec:s0
+/system/vendor/bin/sensors.qcom               u:object_r:sensors_exec:s0
+/system/vendor/bin/wcnss_service              u:object_r:wcnss_service_exec:s0
+
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0


### PR DESCRIPTION
These are sony specific changes and should be separate from qcom/sepolicy

Signed-off-by: Adam Farden adam@farden.cz

Conflicts:
    sepolicy/file_contexts
