### PR TITLE
kanuti: init: Use predefined readahead values from kernel

### DIFF
--- a/rootdir/init.kanuti.rc
+++ b/rootdir/init.kanuti.rc
@@ -113,11 +113,6 @@ on early-boot
     setrlimit 8 67108864 67108864
 
 on boot
-
-    # read ahead buffer
-    write /sys/block/mmcblk0/queue/read_ahead_kb 512
-    write /sys/block/mmcblk1/queue/read_ahead_kb 512
-
     # PM8941 flash
     chown media system /sys/class/misc/pm8941-flash/device/current1
     chown media system /sys/class/misc/pm8941-flash/device/current2


### PR DESCRIPTION
readahead values:
sonyxperiadev/kernel@02246ee

Signed-off-by: Humberto Borba humberos@gmail.com
