### PR TITLE
kanuti: Remove obsolete sepolicy define

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -71,5 +71,3 @@ BOARD_HAVE_BLUETOOTH_QCOM := true
 # NFC
 NFC_NXP_CHIP_TYPE := PN547C2
 
-# SELinux
-BOARD_SEPOLICY_DIRS += device/sony/kanuti/sepolicy


### PR DESCRIPTION
No longer needed, moved to device-sony-common.
