### PR TITLE
kanuti: ueventd: Add common lights sysfs path

### DIFF
--- a/rootdir/ueventd.kanuti.rc
+++ b/rootdir/ueventd.kanuti.rc
@@ -104,6 +104,8 @@
 # LED
 /sys/devices/soc.0/78b6000.i2c/i2c-0/0-0030/leds/led:* max_brightness          0644 root system
 /sys/devices/soc.0/78b6000.i2c/i2c-0/0-0030/leds/led:* brightness              0664 system system
+/sys/class/leds/lcd-backlight/max_brightness                                   0644 root system
+/sys/class/leds/lcd-backlight/brightness                                       0664 system system
 /sys/devices/soc.0/1a00000.qcom,mdss_mdp/qcom,mdss_fb_primary.126/leds/lcd-backlight max_brightness 0664 system system
 /sys/devices/soc.0/1a00000.qcom,mdss_mdp/qcom,mdss_fb_primary.126/leds/lcd-backlight brightness     0664 system system
 


### PR DESCRIPTION
Since lights HAL is unified then all platforms
should be set this permission for system.
