### PR TITLE
kanuti: Build SimToolKit

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -86,6 +86,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     keystore.msm8916
 
+# SimToolKit
+PRODUCT_PACKAGES += \
+    Stk
+
 # Bluetooth
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qualcomm.bt.hci_transport=smd


### PR DESCRIPTION
there is not windy device in kanuti family so it can be defined in kanuti-common

Signed-off-by: David Viteri davidteri91@gmail.com
