### PR TITLE
Move sysfs and props for cpuquiet hotplugging

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -75,6 +75,9 @@ BOARD_HAVE_BLUETOOTH_QCOM := true
 # NFC
 NFC_NXP_CHIP_TYPE := PN547C2
 
+# Props for hotplugging
+TARGET_SYSTEM_PROP += device/sony/kanuti/system.prop
+
 # SELinux
 BOARD_SEPOLICY_DIRS += device/sony/kanuti/sepolicy
 

--- a/rootdir/init.kanuti.pwr.rc
+++ b/rootdir/init.kanuti.pwr.rc
@@ -12,6 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+on init
+    # cpuquiet rqbalance permissions
+    chown system system /sys/devices/system/cpu/cpuquiet/nr_min_cpus
+    chown system system /sys/devices/system/cpu/cpuquiet/nr_power_max_cpus
+    chown system system /sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/nr_min_cpus
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/nr_power_max_cpus
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+
 on charger
     # Enable Power modes and set the CPU Freq Sampling rates
     write /sys/module/msm_thermal/core_control/enabled 0

--- a/rootdir/ueventd.kanuti.rc
+++ b/rootdir/ueventd.kanuti.rc
@@ -180,3 +180,10 @@
 /sys/devices/virtual/input/input* rept_z                   0664  system   system
 /sys/devices/virtual/input/input* test                     0664  system   system
 
+# cpuquiet rqbalance permissions
+/sys/devices/system/cpu/cpuquiet/nr_min_cpus                         0660 system system
+/sys/devices/system/cpu/cpuquiet/nr_power_max_cpus                   0660 system system
+/sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus                 0660 system system
+/sys/devices/system/cpu/cpuquiet/rqbalance/balance_level             0660 system system
+/sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds         0660 system system
+/sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds    0660 system system

--- a/system.prop
+++ b/system.prop
@@ -1,0 +1,15 @@
+#
+# rqbalance specific values
+#
+
+cpuquiet.low.min_cpus=1
+cpuquiet.low.max_cpus=4
+rqbalance.low.balance_level=80
+rqbalance.low.up_threshold=200 450 550 580 600 640 750 4294967295
+rqbalance.low.down_threshold=0 120 320 400 440 500 550 700
+
+cpuquiet.normal.min_cpus=4
+cpuquiet.normal.max_cpus=8
+rqbalance.normal.balance_level=40
+rqbalance.normal.up_threshold=100 300 400 500 525 600 700 4294967295
+rqbalance.normal.down_threshold=0 100 300 400 425 500 600 650


### PR DESCRIPTION
Core limiting via msm_performance works well, but cpuquiet absolutely
hates it. rqbalance is not aware of msm_performance so it spams dmesg
because it cannot online a core for 'unknown' reasons.

We can achieve the same result using cpuquiet which rqbalance is
aware of. We can also have two sources of core limiting, power
profile and thermal.

We also need to tune rqbalance and cpuquiet per platform so also
move their system props.

Signed-off-by: Adam Farden adam@farden.cz
