### PR TITLE
[KANUTI] system.prop: Tune rqbalance for linear core scaling in normal mode

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -8,8 +8,8 @@ rqbalance.low.balance_level=80
 rqbalance.low.up_threshold=200 450 550 580 600 640 750 4294967295
 rqbalance.low.down_threshold=0 120 320 400 440 500 550 700
 
-cpuquiet.normal.min_cpus=4
+cpuquiet.normal.min_cpus=2
 cpuquiet.normal.max_cpus=8
 rqbalance.normal.balance_level=40
-rqbalance.normal.up_threshold=100 300 400 500 525 600 700 4294967295
-rqbalance.normal.down_threshold=0 100 300 400 425 500 600 650
+rqbalance.normal.up_threshold=100 200 350 400 490 545 600 4294967295
+rqbalance.normal.down_threshold=0 70 170 280 340 400 490 545


### PR DESCRIPTION
RQBalance has a special management algorithm for HMP SoC
which manages BIG cores sligthly differently from LITTLE
ones.

When we try to up 4 LITTLE cores, it will instead upcore
2 LITTLE and one BIG, since the computational power of
the BIG ones is more than 2x the LITTLEs.
It will then upcore one more LITTLE if computational power
is still not enough.

Setting the min cores to a number that is equal to MAX
of LITTLE cluster cores, we are breaking this behavior
resulting in a less efficient and not (power)linear
up/downcore management, hence, the minimum cores to make
the mechanism to work efficiently is 2 on Kitakami (MSM8994).

Moreover, tune the NORMAL thresholds for more performance
under Android OS: this optimizes SoC efficiency by using
more cores at lower (middle step) frequency, resulting
in slightly more performance at less power cost.
