### PR TITLE
fstab: Allow recovery to use the misc partition

### DIFF
--- a/rootdir/fstab.kanuti
+++ b/rootdir/fstab.kanuti
@@ -1,11 +1,12 @@
 /dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1,discard                             wait
 /dev/block/bootdevice/by-name/userdata     /data        ext4    nosuid,nodev,barrier=1,noauto_da_alloc,discard   wait,check,encryptable=footer
 /dev/block/bootdevice/by-name/cache        /cache       ext4    nosuid,nodev,discard                             wait,check
+/dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                         defaults
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    defaults                                         defaults
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                         defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                         defaults
 /dev/block/bootdevice/by-name/persist      /persist     ext4    defaults                                         defaults
 
-/devices/soc/7864900.sdhci/mmc_host*         auto         auto    nosuid,nodev                                     voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/platform/msm_hsusb*                   auto         auto    nosuid,nodev                                     voldmanaged=usbdisk:auto
-/dev/block/zram0                               none         swap    defaults                                         zramsize=536870912,notrim
+/devices/soc/7864900.sdhci/mmc_host*       auto         auto    nosuid,nodev                                     voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/msm_hsusb*               auto         auto    nosuid,nodev                                     voldmanaged=usbdisk:auto
+/dev/block/zram0                           none         swap    defaults                                         zramsize=536870912,notrim


### PR DESCRIPTION
Android Nougat changed how it communicates with the recovery
partition. Until now the recovery commands had been written
to the /cache partition, but this has changed. Now recovery
writes to the /misc partition.

Fortunately for kanuti devices we actually have
an empty and unused /apps_log partition we can use.

apps_log -> /dev/block/mmcblk0p26

Signed-off-by: Adam Farden <adam@farden.cz>
Signed-off-by: David Viteri <davidteri91@gmail.com>