### PR TITLE
sony: kanuti: Set BT default name dynamically

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -17,6 +17,22 @@
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
 
+#include <cutils/properties.h>
+#include <string.h>
+
+inline const char* getBTDefaultName()
+{
+    char device[PROPERTY_VALUE_MAX];
+    property_get("ro.boot.hardware", device, "");
+
+    if (!strcmp("tulip", device)) {
+        return "Xperia M4 Aqua";
+    }
+
+    return "Xperia";
+}
+
+#define BTM_DEF_LOCAL_NAME getBTDefaultName()
 #define BTA_HOST_INTERLEAVE_SEARCH  TRUE
 
 #endif


### PR DESCRIPTION
Use ro.boot.hardware property and naming BT dynamically.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I5ec4d262af3d0e55d9f93fdb3ca4e0d6e49dbc8f