### PR TITLE
kanuti: use correct flag nfc for android-7.1.1

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -76,7 +76,7 @@ BOARD_HAVE_BLUETOOTH := true
 BOARD_HAVE_BLUETOOTH_QCOM := true
 
 # NFC
-NFC_NXP_CHIP_TYPE := PN547C2
+NXP_CHIP_TYPE := PN547C2
 
 # FM definitions for Qualcomm solution
 BOARD_HAVE_ALTERNATE_FM := true


### PR DESCRIPTION
following marlin config https://android.googlesource.com/device/google/marlin/+/android-7.1.1_r8/marlin/BoardConfig.mk#200

Signed-off-by: David Viteri <davidteri91@gmail.com>