### PR TITLE
[n-mr1] kanuti: remove boot_cpus from CMDLINE

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -39,7 +39,7 @@ BOARD_KERNEL_TAGS_OFFSET := 0x01E00000
 BOARD_RAMDISK_OFFSET     := 0x02000000
 
 BOARD_KERNEL_CMDLINE += console=ttyHSL0,115200,n8
-BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1 boot_cpus=0-5
+BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
 


### PR DESCRIPTION
we already have this here https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/arch/arm/boot/dts/qcom/msm8939.dtsi#L30
so we don't need to declarate this twice
Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>