### PR TITLE
Add platform-specific file_contexts

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -86,6 +86,6 @@ BOARD_HAVE_QCOM_FM := true
 TARGET_QCOM_NO_FM_FIRMWARE := true
 
 # SELinux
-BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy
+BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
 
 include device/sony/common/CommonConfig.mk

--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -1,0 +1,44 @@
+###################################
+# Dev block nodes
+#
+/dev/block/mmcblk0                                             u:object_r:root_block_device:s0
+/dev/block/mmcblk0rpmb                                         u:object_r:rpmb_device:s0
+
+/dev/block/mmcblk1                                             u:object_r:sd_device:s0
+/dev/block/mmcblk1p1                                           u:object_r:sd_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/modemst1     u:object_r:modem_efs_partition_device:s0
+/dev/block/bootdevice/by-name/modemst1                         u:object_r:modem_efs_partition_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/modemst2     u:object_r:modem_efs_partition_device:s0
+/dev/block/bootdevice/by-name/modemst2                         u:object_r:modem_efs_partition_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/fsg          u:object_r:modem_efs_partition_device:s0
+/dev/block/bootdevice/by-name/fsg                              u:object_r:modem_efs_partition_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/ssd          u:object_r:ssd_device:s0
+/dev/block/bootdevice/by-name/ssd                              u:object_r:ssd_device:s0
+
+/dev/block/mmcblk0p1                                           u:object_r:trim_area_partition_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/TA           u:object_r:trim_area_partition_device:s0
+/dev/block/bootdevice/by-name/TA                               u:object_r:trim_area_partition_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/userdata     u:object_r:userdata_block_device:s0
+/dev/block/bootdevice/by-name/userdata                         u:object_r:userdata_block_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/boot         u:object_r:boot_block_device:s0
+/dev/block/bootdevice/by-name/boot                             u:object_r:boot_block_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/FOTAKernel   u:object_r:recovery_block_device:s0
+/dev/block/bootdevice/by-name/FOTAKernel                       u:object_r:recovery_block_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/cache        u:object_r:cache_block_device:s0
+/dev/block/bootdevice/by-name/cache                            u:object_r:cache_block_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/apps_log     u:object_r:misc_block_device:s0
+/dev/block/bootdevice/by-name/apps_log                         u:object_r:misc_block_device:s0		
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/persist      u:object_r:persist_block_device:s0
+/dev/block/bootdevice/by-name/persist                          u:object_r:persist_block_device:s0
+
+/dev/block/zram0                                               u:object_r:swap_block_device:s0


### PR DESCRIPTION
We have	removed	the dev	block nodes from the common repository
device-sony-sepolicy's file_contexts because it was really
getting too much dirty.... and also, now that UFS has appeared
we had a conflict: on those devices, mmcblk0 is	SDCard,	while
on eMMC	devices	it is the eMMC.

This file_contexts contains only the correct and necessary
block node contexts for	this platform.