### PR TITLE
Use standard AOSP naming conventions for sepolicy block devices

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -2,26 +2,26 @@
 # Dev block nodes
 #
 /dev/block/mmcblk0                                             u:object_r:root_block_device:s0
-/dev/block/mmcblk0rpmb                                         u:object_r:rpmb_device:s0
+/dev/block/mmcblk0rpmb                                         u:object_r:rpmb_block_device:s0
 
-/dev/block/mmcblk1                                             u:object_r:sd_device:s0
-/dev/block/mmcblk1p1                                           u:object_r:sd_device:s0
+/dev/block/mmcblk1                                             u:object_r:sd_block_device:s0
+/dev/block/mmcblk1p1                                           u:object_r:sd_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/modemst1        u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/modemst1                         u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/soc/7824900\.sdhci/by-name/modemst1        u:object_r:modem_block_device:s0
+/dev/block/bootdevice/by-name/modemst1                         u:object_r:modem_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/modemst2        u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/modemst2                         u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/soc/7824900\.sdhci/by-name/modemst2        u:object_r:modem_block_device:s0
+/dev/block/bootdevice/by-name/modemst2                         u:object_r:modem_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/fsg             u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/fsg                              u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/soc/7824900\.sdhci/by-name/fsg             u:object_r:modem_block_device:s0
+/dev/block/bootdevice/by-name/fsg                              u:object_r:modem_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/ssd             u:object_r:ssd_device:s0
-/dev/block/bootdevice/by-name/ssd                              u:object_r:ssd_device:s0
+/dev/block/platform/soc/7824900\.sdhci/by-name/ssd             u:object_r:ssd_block_device:s0
+/dev/block/bootdevice/by-name/ssd                              u:object_r:ssd_block_device:s0
 
-/dev/block/mmcblk0p1                                           u:object_r:trim_area_partition_device:s0
-/dev/block/platform/soc/7824900\.sdhci/by-name/TA              u:object_r:trim_area_partition_device:s0
-/dev/block/bootdevice/by-name/TA                               u:object_r:trim_area_partition_device:s0
+/dev/block/mmcblk0p1                                           u:object_r:ta_block_device:s0
+/dev/block/platform/soc/7824900\.sdhci/by-name/TA              u:object_r:ta_block_device:s0
+/dev/block/bootdevice/by-name/TA                               u:object_r:ta_block_device:s0
 
 /dev/block/platform/soc/7824900\.sdhci/by-name/userdata        u:object_r:userdata_block_device:s0
 /dev/block/bootdevice/by-name/userdata                         u:object_r:userdata_block_device:s0


### PR DESCRIPTION
By using the standard AOSP naming conventions when labelling
our block devices, we take advantage of exising sepilicy rules
which means we don't need to write as many of our own rules.

This changes requires a corresponding change in device-sony-sepolicy.