### PR TITLE
[o-mr0] init.kanuti.rc: Do not reserve CPU 3 for the camera daemon

### DIFF
--- a/rootdir/init.kanuti.rc
+++ b/rootdir/init.kanuti.rc
@@ -25,13 +25,11 @@ on boot
     write /dev/wcnss_wlan 1
 
     # Update foreground cpuset now that processors are up
-    # reserve CPU 3 for the top app and camera daemon
-    write /dev/cpuset/foreground/cpus 0-2,4-7
+    write /dev/cpuset/foreground/cpus 0-7
     write /dev/cpuset/foreground/boost/cpus 4-7
     write /dev/cpuset/background/cpus 0
     write /dev/cpuset/system-background/cpus 0-2
     write /dev/cpuset/top-app/cpus 0-7
-    write /dev/cpuset/camera-daemon/cpus 0-3
 
 service sensord /system/vendor/bin/sensord
     class main


### PR DESCRIPTION
Camera daemon is no longer used so it makes no sense to reserve
CPU 3 for the camera daemon.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>