### PR TITLE
[o-mr0] remove fstab symlink

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -22,6 +22,10 @@ SOMC_PLATFORM := kanuti
 
 SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 
+# Overlay
+DEVICE_PACKAGE_OVERLAYS += \
+    $(PLATFORM_COMMON_PATH)/overlay
+
 # Audio
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/aanc_tuning_mixer.txt:$(TARGET_COPY_OUT_VENDOR)/etc/aanc_tuning_mixer.txt
@@ -49,9 +53,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/rqbalance_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/rqbalance_config.xml
 
-# Platform Init
+# Platform power configuration
 PRODUCT_PACKAGES += \
-    fstab.kanuti \
     init.kanuti.pwr
 
 # Audio

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,10 +1,10 @@
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := fstab.kanuti
+LOCAL_MODULE := fstab.$(TARGET_DEVICE)
 LOCAL_SRC_FILES := fstab.kanuti
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := fstab.kanuti
+LOCAL_MODULE_STEM := fstab.$(TARGET_DEVICE)
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)
 include $(BUILD_PREBUILT)
@@ -38,5 +38,3 @@ LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)
 include $(BUILD_PREBUILT)
-
-$(shell mkdir -p $(PRODUCT_OUT)/root && pushd $(PRODUCT_OUT)/root > /dev/null && ln -s fstab.kanuti fstab.$(TARGET_DEVICE) && popd > /dev/null)


### PR DESCRIPTION
we can drop the fstab symlink and use real fstab for each device

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>