### PR TITLE
platform.mk: Remove telephony packages

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -80,11 +80,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     camera.msm8916
 
-# Telephony Packages (AOSP)
-PRODUCT_PACKAGES += \
-    InCallUI \
-    Stk
-
 # Bluetooth
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qualcomm.bt.hci_transport=smd


### PR DESCRIPTION
Now telephony packages are declared in the Tulip device repository.
https://github.com/sonyxperiadev/device-sony-tulip/commit/dcb21946122500b892efcb018fb2046c839b3020

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>